### PR TITLE
Update pip before installing duplocloud-client.

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -18,6 +18,7 @@ runs:
     id: install-duploctl
     shell: bash
     run: |
+      pip install --upgrade pip
       pip install duplocloud-client
 
   - name: Portal Info


### PR DESCRIPTION
I think this is the cause of errors like these: https://github.com/duplocloud/terraform-duplocloud-components/actions/runs/6910379369/job/18803415538#step:3:72

Pip is pretty stable, so I usually just let it upgrade to the latest version for things like this.