### PR TITLE
added the k8s job runner

### DIFF
--- a/k8s-job/README.md
+++ b/k8s-job/README.md
@@ -1,0 +1,47 @@
+# Kubernetes Job Runner  
+
+An action to run an arbitrary kubernetes job and watch it until it completes or fails. This will report back the end status as well as the logs from the job.
+
+## Usage
+
+```yaml
+name: K8s Job
+on: 
+- push
+jobs:
+  run-k8s-job:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+    - name: Build Job
+        shell: bash
+        run: |
+          cat <<EOF > job.yaml
+          apiVersion: batch/v1
+          kind: Job
+          metadata:
+            name: my-job
+            namespace: duploservices-mytenant
+          spec:
+            backoffLimit: 4
+            parallelism: 1
+            template:
+              spec:
+                restartPolicy: Never
+                nodeSelector:
+                  tenantname: duploservices-mytenant
+                containers:
+                - name: app
+                  image: alpine:latest
+                  command: 
+                  - /bin/sh
+                  - -c
+                  args:
+                  - |
+                    echo "Hello World, I'm in Kubernetes!"
+          EOF
+
+      - name: Apply and Watch
+        uses: duplocloud/actions/k8s-job@main
+```

--- a/k8s-job/action.yml
+++ b/k8s-job/action.yml
@@ -1,0 +1,71 @@
+name: Run Kubernetes Job 
+description: Runs a Kubernetes job and outputs the pod logs to the console.
+inputs:
+  file: 
+    description: 'The file with a k8s job to run'
+    default: job.yaml
+  timeout:
+    description: 'The timeout for the job'
+    default: 300s
+runs:
+  using: composite
+  steps:
+
+  - name: Apply and Watch
+    shell: bash
+    env:
+      JOB_FILE: ${{ inputs.file }}
+      JOB_TIMEOUT: ${{ inputs.timeout }}
+    run: |
+      export JOB JOB_NAME NAMESPACE PODS
+      JOB="$(cat "$JOB_FILE")"
+
+      JOB_NAME="$(echo "$JOB" | yq -r '.metadata.name')"
+      NAMESPACE="$(echo "$JOB" | yq -r '.metadata.namespace')"
+
+      function pod_logs() {
+        wait_for_resource "pods/${1}" && \
+        kubectl wait \
+          --for=condition=Ready \
+          -n "$NAMESPACE" \
+          --timeout="${JOB_TIMEOUT}" \
+          "pods/${1}" && \
+        kubectl logs "pods/$1" -n "$NAMESPACE" --follow
+      }
+
+      function wait_for_resource() {
+        while : ; do
+          res="$(kubectl get "$1" -n "$NAMESPACE" 2>&1)" && break
+          sleep 2
+        done
+      }
+
+      kubectl apply -f "$JOB_FILE"
+
+      wait_for_resource "jobs/${JOB_NAME}"
+
+      # shellcheck disable=SC2207
+      PODS=($(kubectl get pods \
+        -l job-name="${JOB_NAME}" \
+        -n "$NAMESPACE" \
+        --no-headers \
+        --output=custom-columns=:metadata.name))
+
+      length="${#PODS[@]}"
+
+      echo "Waiting for ${JOB_NAME} to complete and ${length} pods to be ready"
+      kubectl wait \
+        --for=condition=Complete \
+        --timeout="${JOB_TIMEOUT}" \
+        -n "$NAMESPACE" \
+        "jobs/${JOB_NAME}" &
+
+      for pod in "${PODS[@]}"; do
+        pod_logs "$pod" &
+      done
+
+      wait
+
+      kubectl delete -f "$JOB_FILE"
+
+      echo "Exectued ${length} pods for job ${JOB_NAME}"


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Introduced a new GitHub Action for running Kubernetes jobs, including monitoring and log retrieval.
- Added comprehensive documentation in README.md, detailing usage and configuration steps.
- The action script handles job application, monitoring for completion, log output, and cleanup.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Added README for Kubernetes Job Runner with Usage Guide</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
k8s-job/README.md

<li>Introduced a README file for the Kubernetes Job Runner.<br> <li> Provided a detailed usage guide including a YAML configuration example <br>for running a Kubernetes job.<br> <li> Explained how to build and apply a Kubernetes job using a bash script.<br> <br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/actions/pull/7/files#diff-995d19ea71f7c1ab48459326ee6c6a2739553c283aaffad73d0633e5114b30e8">+47/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Implemented Action to Run and Monitor Kubernetes Jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
k8s-job/action.yml

<li>Created an action to run and monitor Kubernetes jobs.<br> <li> Defined inputs for the job file and timeout with defaults.<br> <li> Implemented bash scripts for applying the job, waiting for its <br>completion, fetching logs, and cleanup.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/actions/pull/7/files#diff-495bfd2d5badb4dc32eb8b5ea305dbf4a1533d2af86bc9b79015c72fa03d7f27">+71/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
