### PR TITLE
fix input name mismatch on name input

### DIFF
--- a/update-image/action.yml
+++ b/update-image/action.yml
@@ -29,6 +29,6 @@ runs:
     shell: bash
     env:
       RESOURCE: ${{ inputs.type }}
-      NAME: ${{ inputs.service }}
+      NAME: ${{ inputs.name }}
       IMAGE: ${{ inputs.image }}
     run: duploctl $RESOURCE update_image $NAME $IMAGE


### PR DESCRIPTION
## **User description**
🙈


___

## **Type**
bug_fix


___

## **Description**
- Corrected the input variable name from `service` to `name` to match the expected input, ensuring the action correctly updates the image using the provided name.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Fix Input Name Mismatch in GitHub Action</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
update-image/action.yml

<li>Fixed an input name mismatch by changing <code>inputs.service</code> to <br><code>inputs.name</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/actions/pull/28/files#diff-5784903c938ebea33e28eee6aae21d06173c7431174a413e1ae821361d96ce09">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

