### PR TITLE
Handle race conditions on node startup and fast pods

### DIFF
--- a/k8s-job/README.md
+++ b/k8s-job/README.md
@@ -39,6 +39,11 @@ jobs:
                   - -c
                   args:
                   - |
+                    # Jobs that exit immediately may fail the wait conditions above or be missing logs.
+                    # Most jobs take at least a few seconds to complete, so this isn't an issue. If your
+                    # job exits too quickly, inject some seconds of sleep. Upcoming Kubernetes features
+                    # may simplify this.
+                    sleep 10
                     echo "Hello World, I'm in Kubernetes!"
           EOF
 

--- a/k8s-job/action.yml
+++ b/k8s-job/action.yml
@@ -33,7 +33,18 @@ runs:
           -n "$NAMESPACE" \
           --timeout="${JOB_TIMEOUT}" \
           "pods/${1}" && \
-        kubectl logs "pods/$1" -n "$NAMESPACE" --follow
+        # If the pod is placed on a node that just started (e.g. because the job triggered a scale up) and we try to
+        # get logs too quickly, sometimes we get TLS errors from the node. Waiting for the node to be in the "Ready" state
+        # doesn't reliably resolve this, and also can't be done with tenant-scoped permissions.
+        retries=5
+        while ! kubectl logs "pods/$1" -n "$NAMESPACE" --follow; do
+            retries=$((retries-1))
+            if [ "$retries" == "0" ]; then
+                break
+            fi
+            echo "Retrying..."
+            sleep 5
+        done
       }
 
       # Function to wait for the existence of a Kubernetes resource

--- a/k8s-job/action.yml
+++ b/k8s-job/action.yml
@@ -25,6 +25,22 @@ runs:
       JOB_NAME="$(echo "$JOB" | yq -r '.metadata.name')"
       NAMESPACE="$(echo "$JOB" | yq -r '.metadata.namespace')"
 
+      # Function to get logs from new hosts that may take a moment to become ready
+      function safe_logs() {
+        # If the pod is placed on a node that just started (e.g. because the job triggered a scale up) and we try to
+        # get logs too quickly, sometimes we get TLS errors from the node. Waiting for the node to be in the "Ready" state
+        # doesn't reliably resolve this, and also can't be done with tenant-scoped permissions.
+        retries=5
+        while ! kubectl logs "pods/$1" -n "$NAMESPACE" --follow; do
+          retries=$((retries-1))
+          if [ "$retries" == "0" ]; then
+            break
+          fi
+          echo "Retrying..."
+          sleep 5
+        done
+      }
+
       # Function to output pod logs
       function pod_logs() {
         wait_for_resource "pods/${1}" && \
@@ -33,18 +49,7 @@ runs:
           -n "$NAMESPACE" \
           --timeout="${JOB_TIMEOUT}" \
           "pods/${1}" && \
-        # If the pod is placed on a node that just started (e.g. because the job triggered a scale up) and we try to
-        # get logs too quickly, sometimes we get TLS errors from the node. Waiting for the node to be in the "Ready" state
-        # doesn't reliably resolve this, and also can't be done with tenant-scoped permissions.
-        retries=5
-        while ! kubectl logs "pods/$1" -n "$NAMESPACE" --follow; do
-            retries=$((retries-1))
-            if [ "$retries" == "0" ]; then
-                break
-            fi
-            echo "Retrying..."
-            sleep 5
-        done
+        safe_logs "$1"
       }
 
       # Function to wait for the existence of a Kubernetes resource


### PR DESCRIPTION
### **User description**
See code comments for race condition details.

Successful use of the loop in a local script running a copy/paste of the change in this PR handling the node race condition:
```
job.batch/script-test created
Waiting for script-test to complete and 1 pods to be ready
pod/script-test-mxwt4 condition met
Error from server: Get "https://10.231.14.178:10250/containerLogs/duploservices-qa01/script-test-mxwt4/app?follow=true": remote error: tls: internal error
Retrying...
Success. # This was the output of a test job.
job.batch/script-test condition met
job.batch "script-test" deleted
Executed 1 pods for job script-test
```

I intentionally don't hide error output in case something happens that's outside the specific case I was solving in this PR.

Successful run in a test GHA job of this branch:

![Screenshot 2024-07-12 at 10 48 34 AM](https://github.com/user-attachments/assets/48f160f0-1fef-4232-9d25-766b0822056c)

The environment where this GHA job ran didn't readily reproduce the race condition, which is why I used the script run above in the environment where this was happening. The GHA run was more to verify that copy/pasting the change didn't have any indentation or other problems that might break the action version of it.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added documentation in `README.md` to address potential issues with jobs that exit immediately and suggested using a sleep command as a workaround.
- Implemented a retry mechanism in `action.yml` to handle TLS errors when fetching pod logs, including explanatory comments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add documentation for handling fast job completions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s-job/README.md

<li>Added a note about potential issues with jobs that exit immediately <br>and a suggested workaround.<br> <li> Included a <code>sleep 10</code> command to mitigate fast job completion issues.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/actions/pull/32/files#diff-995d19ea71f7c1ab48459326ee6c6a2739553c283aaffad73d0633e5114b30e8">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Add retry mechanism for fetching pod logs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s-job/action.yml

<li>Implemented a retry mechanism for fetching pod logs to handle TLS <br>errors.<br> <li> Added comments explaining the retry logic and its necessity.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/actions/pull/32/files#diff-495bfd2d5badb4dc32eb8b5ea305dbf4a1533d2af86bc9b79015c72fa03d7f27">+12/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

