### PR TITLE
GIT_REF tag causes issues with repos with immutable tags enabled

### DIFF
--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -21,8 +21,8 @@ inputs:
   tags:
     description: Extra space delimited tags to add to the image
     required: false
-  fancy-tags:
-    description: Space delimited tags provided by Duplocloud. Choose one or more of DATE, GIT_REF, and/or GIT_SHA. Date is in UTC.
+  tag-strategy:
+    description: Space delimited computed tag strategy. Choose one or more of DATE, GIT_REF, and/or GIT_SHA. Date is in UTC.
     required: false
     default: GIT_REF GIT_SHA
   target:
@@ -201,7 +201,7 @@ runs:
       PLATFORMS: ${{ inputs.platforms }}
       MULTIARCH: "false"
       EXTRA_TAGS: ${{ inputs.tags }}
-      FANCY_TAGS: ${{ inputs.fancy-tags }}
+      FANCY_TAGS: ${{ inputs.tag-strategy }}
       IMAGE: ${{ steps.image-env.outputs.image }}
       GIT_SHA: ${{ steps.image-env.outputs.git_sha }}
       GIT_REF: ${{ steps.image-env.outputs.git_ref }}

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -261,7 +261,7 @@ runs:
       # add all the tags with image as args
       TAGS=(
         $EXTRA_TAGS
-        $COMPUTED_FANCY_TAGS
+        $COMPUTED_FANCY_TAGS[@]
       )
       for tag in ${TAGS[*]}; do
         ARGS+=(--tag "${IMAGE}:${tag}")

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -254,15 +254,15 @@ runs:
       COMPUTED_FANCY_TAGS=()
       ALLOWED_FANCY_TAGS=(DATE GIT_REF GIT_SHA)
       for tag in "${ALLOWED_FANCY_TAGS[@]}"; do
-        if [[ "${fancy-tags}" =~ "$tag" ]]; then
+        if [[ "${FANCY_TAGS}" =~ "$tag" ]]; then
           echo "adding fancy tag $tag"
-          FANCY_TAGS+=("${!tag}")
+          COMPUTED_FANCY_TAGS+=("${!tag}")
         fi
       done
       # add all the tags with image as args
       TAGS=(
         $EXTRA_TAGS
-        $FANCY_TAGS
+        $COMPUTED_FANCY_TAGS
       )
       for tag in ${TAGS[*]}; do
         echo "FOUND TAG ${tag}"

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -261,7 +261,7 @@ runs:
       # add all the tags with image as args
       TAGS=(
         $EXTRA_TAGS
-        "${COMPUTED_FANCY_TAGS[@]}"
+        "${COMPUTED_FANCY_TAGS[*]}"
       )
       for tag in ${TAGS[*]}; do
         ARGS+=(--tag "${IMAGE}:${tag}")

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -21,7 +21,7 @@ inputs:
   tags:
     description: Extra space delimited tags to add to the image
     required: false
-  fancy_tags:
+  fancy-tags:
     description: Space delimited tags provided by Duplocloud. Choose one or more of DATE, GIT_REF, and/or GIT_SHA. Date is in UTC.
     required: false
     default: GIT_REF GIT_SHA

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -255,7 +255,6 @@ runs:
       ALLOWED_FANCY_TAGS=(DATE GIT_REF GIT_SHA)
       for tag in "${ALLOWED_FANCY_TAGS[@]}"; do
         if [[ "${FANCY_TAGS}" =~ "$tag" ]]; then
-          echo "adding fancy tag $tag"
           COMPUTED_FANCY_TAGS+=("${!tag}")
         fi
       done
@@ -265,7 +264,6 @@ runs:
         $COMPUTED_FANCY_TAGS
       )
       for tag in ${TAGS[*]}; do
-        echo "FOUND TAG ${tag}"
         ARGS+=(--tag "${IMAGE}:${tag}")
       done
       

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -251,7 +251,7 @@ runs:
       FANCY_TAGS=()
       ALLOWED_FANCY_TAGS=(DATE GIT_REF GIT_SHA)
       for tag in "${ALLOWED_FANCY_TAGS[@]}"; do
-        if [[ "${fancy_tags}" =~ "$tag" ]]; then
+        if [[ "${fancy-tags}" =~ "$tag" ]]; then
           FANCY_TAGS+=($tag)
         fi
       done
@@ -261,6 +261,7 @@ runs:
         $FANCY_TAGS
       )
       for tag in ${TAGS[*]}; do
+        echo "FOUND TAG ${tag}"
         ARGS+=(--tag "${IMAGE}:${tag}")
       done
       

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: Extra space delimited tags to add to the image
     required: false
   fancy_tags:
-    description: Space delimited tags provided by Duplocloud. Options are DATE, GIT_REF, and/or GIT_SHA. Date is in UTC.
+    description: Space delimited tags provided by Duplocloud. Choose one or more of DATE, GIT_REF, and/or GIT_SHA. Date is in UTC.
     required: false
     default: GIT_REF GIT_SHA
   target:
@@ -255,16 +255,10 @@ runs:
           FANCY_TAGS+=($tag)
         fi
       done
-
-
       # add all the tags with image as args
       TAGS=(
         $EXTRA_TAGS
         $FANCY_TAGS
-      )
-      FANCY_TAGS=(
-        $GIT_SHA
-        $GIT_REF
       )
       for tag in ${TAGS[*]}; do
         ARGS+=(--tag "${IMAGE}:${tag}")

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -21,6 +21,10 @@ inputs:
   tags:
     description: Extra space delimited tags to add to the image
     required: false
+  fancy_tags:
+    description: Space delimited tags provided by Duplocloud. Options are DATE, GIT_REF, and/or GIT_SHA. Date is in UTC.
+    required: false
+    default: GIT_REF GIT_SHA
   target:
     description: Target stage to build
     required: false
@@ -161,6 +165,8 @@ runs:
       GIT_SHA="$(git rev-parse --short HEAD)"
       echo "Short sha is $GIT_SHA"
 
+      DATE="$(date -u +"%Y%m%d%H%M")"
+
       # ref name
       ## TODO: maybe use this GITHUB_REF_NAME
       # the sed part handles dependabot issues with slash names
@@ -241,9 +247,22 @@ runs:
         ARGS+=(--build-arg "${arg}")
       done
 
+      # Add the fancy tags
+      FANCY_TAGS=()
+      ALLOWED_FANCY_TAGS=(DATE GIT_REF GIT_SHA)
+      for tag in "${ALLOWED_FANCY_TAGS[@]}"; do
+        if [[ "${fancy_tags}" =~ "$tag" ]]; then
+          FANCY_TAGS+=($tag)
+        fi
+      done
+
+
       # add all the tags with image as args
       TAGS=(
         $EXTRA_TAGS
+        $FANCY_TAGS
+      )
+      FANCY_TAGS=(
         $GIT_SHA
         $GIT_REF
       )

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -179,6 +179,7 @@ runs:
       echo "git_ref=${GIT_REF}" >> $GITHUB_OUTPUT
       echo "git_sha=${GIT_SHA}" >> $GITHUB_OUTPUT
       echo "uri=${IMAGE}:${GIT_SHA}" >> $GITHUB_OUTPUT
+      echo "date=${DATE}" >> GITHUB_OUTPUT
 
   # setup the base image
   - name: Setup CLI Args
@@ -200,9 +201,11 @@ runs:
       PLATFORMS: ${{ inputs.platforms }}
       MULTIARCH: "false"
       EXTRA_TAGS: ${{ inputs.tags }}
+      FANCY_TAGS: ${{ inputs.fancy-tags }}
       IMAGE: ${{ steps.image-env.outputs.image }}
       GIT_SHA: ${{ steps.image-env.outputs.git_sha }}
       GIT_REF: ${{ steps.image-env.outputs.git_ref }}
+      DATE: ${{ steps.image-env.outputs.date }}
     run: |
       ARGS=($EXTRA_ARGS)
 
@@ -248,11 +251,12 @@ runs:
       done
 
       # Add the fancy tags
-      FANCY_TAGS=()
+      COMPUTED_FANCY_TAGS=()
       ALLOWED_FANCY_TAGS=(DATE GIT_REF GIT_SHA)
       for tag in "${ALLOWED_FANCY_TAGS[@]}"; do
         if [[ "${fancy-tags}" =~ "$tag" ]]; then
-          FANCY_TAGS+=($tag)
+          echo "adding fancy tag $tag"
+          FANCY_TAGS+=("${!tag}")
         fi
       done
       # add all the tags with image as args

--- a/build-image/action.yml
+++ b/build-image/action.yml
@@ -261,7 +261,7 @@ runs:
       # add all the tags with image as args
       TAGS=(
         $EXTRA_TAGS
-        $COMPUTED_FANCY_TAGS[@]
+        "${COMPUTED_FANCY_TAGS[@]}"
       )
       for tag in ${TAGS[*]}; do
         ARGS+=(--tag "${IMAGE}:${tag}")


### PR DESCRIPTION
This pr allows the user to set `tag-strategy` to one or more of date, git_ref, or git_sha to tag their images with tags computed by the action.  
