### PR TITLE
Fix az login error when updating image 

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -169,7 +169,7 @@ runs:
   - name: Azure CLI script
     id: setup-azure-cli
     uses: azure/CLI@v2
-    if: env.AZURE_ENABLED == 'true'
+    if: env.AZURE_ENABLED == 'true' && inputs.credentials
     with:
       azcliversion: 2.57.0
       inlineScript: |

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -151,7 +151,7 @@ runs:
   - name: Set up Cloud SDK
     id: setup-gcloud
     uses: google-github-actions/setup-gcloud@v2
-    if: env.GCP_ENABLED == 'true'
+    if: env.GCP_ENABLED == 'true' && inputs.credentials
     with:
       version: '>= 363.0.0'
 


### PR DESCRIPTION
This fixes a corner case bug when updating an image without any other dependency on azure or gcp. 

# Background: 
Most users who run an azure duplo portal also login to azure to push their image to a registry. 
Some users have no such dependency on azure. 

The setup action detects if the portal is GCP or Azure, and then runs login if credentials are set. 
For the azure path It then runs `az accounts show`, regardless if credentials are set. This means that if no credentials are set, `az accounts show` fails since there was no preceeding login. 

# Fix
The fix is to check if credentials are set for both steps. This stops `az accounts show` from running if `az login` was not also run.

Same fixed applied to the GCP path.  

# Testing

Testing by running an action that points to the commit `uses: duplocloud/actions/setup@c72f81f5db659531f5747d4d6260b66f34a25849`. Verified it did not error on the `az accounts show` step. 

# Alternate considered: 
* Can just remove the az show step. 

