### PR TITLE
use uv instead of pip

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -31,10 +31,9 @@ runs:
     with:
       python-version: '3.10'
 
-  - name: Pip Upgrade
-    shell: bash
-    run: pip install --upgrade pip
-
+  - name: Install uv
+    uses: astral-sh/setup-uv@v5
+  
   - name: Install duploctl
     id: install-duploctl
     shell: bash
@@ -42,9 +41,9 @@ runs:
       VERSION: ${{ inputs.version }}
     run: |
       if [[ "$VERSION" == "latest" ]]; then
-        pip install duplocloud-client
+        uv pip install duplocloud-client --system
       else
-        pip install duplocloud-client==$VERSION
+        uv pip install duplocloud-client=$VERSION --system
       fi
       
   - name: Duplo Version

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -41,9 +41,9 @@ runs:
       VERSION: ${{ inputs.version }}
     run: |
       if [[ "$VERSION" == "latest" ]]; then
-        uv pip install duplocloud-client --system
+        uv pip install duplocloud-client --system || exit 1
       else
-        uv pip install duplocloud-client=$VERSION --system
+        uv pip install duplocloud-client==$VERSION --system || exit 1
       fi
       
   - name: Duplo Version


### PR DESCRIPTION
### **User description**
This pull request includes changes to the `setup/action.yml` file to update the installation process and improve dependency management.

Dependency management updates:

* Replaced the `Pip Upgrade` step with the `Install uv` step using the `astral-sh/setup-uv@v5` action.
* Updated the `duplocloud-client` installation commands to use `uv` for both the latest and specific version installations, ensuring the `--system` flag is used.


___

### **PR Type**
Enhancement


___

### **Description**
- Replaced `pip` with `uv` for dependency management.

- Updated `setup/action.yml` to use `astral-sh/setup-uv@v5`.

- Ensured `uv` is used for both latest and specific version installations.

- Improved dependency installation with the `--system` flag.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Updated dependency management to use `uv`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup/action.yml

<li>Replaced <code>pip</code> upgrade step with <code>uv</code> installation.<br> <li> Updated dependency installation commands to use <code>uv</code>.<br> <li> Added <code>--system</code> flag to <code>uv</code> installation commands.


</details>


  </td>
  <td><a href="https://github.com/duplocloud/actions/pull/45/files#diff-0a9aab6a50f3bbdec6e276c293c50c88f6fe9090b94442ca288b8d983bd19dc7">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information