### PR TITLE
DUPLO-36952: Add build-image action support to build and push docker image to Azure Container Registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - an override for the bucket name on the terrafom-module action
 - Validation to prevent redundant duploctl install in setup
 - Added condition to skip setting python and pip upgrade when python-version is 'none'
+- Added build-image support to build and push docker image to Azure Container Registry
 
 ## [0.0.12] - 2025-04-15
 


### PR DESCRIPTION
# Description

This PR introduces a Duplocloud GitHub Actions to automate the process of building and pushing Docker images to Azure Container Registry (ACR).

# Link

https://app.clickup.com/t/8655600/DUPLO-36952