### PR TITLE
fix(ai-helpdesk): add vars to summary env

### DIFF
--- a/ai-helpdesk/action.yml
+++ b/ai-helpdesk/action.yml
@@ -126,6 +126,9 @@ runs:
 
   - name: Build Step Summary
     shell: bash
+    env:
+      AGENT_NAME: ${{ inputs.agent_name }}
+      AGENT_INSTANCE: ${{ inputs.agent_instance }}
     run: |
       TICKET_NAME=$(grep -o '"ticketname": "[^"]*"' /tmp/duploctl_output.json | cut -d'"' -f4 || echo "")
       CHAT_URL=$(grep -o '"chat_url": "[^"]*"' /tmp/duploctl_output.json | cut -d'"' -f4 || echo "")


### PR DESCRIPTION
### **User description**
This pull request makes a minor update to the GitHub Action workflow by setting two environment variables, `AGENT_NAME` and `AGENT_INSTANCE`, for the "Build Step Summary" step. This allows the step to access these input values during execution.

* Set `AGENT_NAME` and `AGENT_INSTANCE` environment variables in the "Build Step Summary" step of `ai-helpdesk/action.yml` to make action inputs available in the shell script.


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing environment variables to GitHub Action step

- Fix access to `AGENT_NAME` and `AGENT_INSTANCE` inputs in summary step


___

### Diagram Walkthrough


```mermaid
flowchart LR
  inputs["Action Inputs"] -- "expose as env vars" --> summary["Build Step Summary"]
  summary -- "access AGENT_NAME & AGENT_INSTANCE" --> script["Shell Script"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Add environment variables to summary step</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ai-helpdesk/action.yml

<ul><li>Add <code>env</code> section to "Build Step Summary" step<br> <li> Set <code>AGENT_NAME</code> and <code>AGENT_INSTANCE</code> environment variables from action <br>inputs<br> <li> Enable shell script access to previously unavailable input values</ul>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/actions/pull/75/files#diff-dbf6ac0c16aff3a6f8978c4e32df76fa05c7d72c342b95009687da5a8f642483">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

