### PR TITLE
DUPLO-29546: support sidecar and init container images in update-image action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `update-image` action now supports updating sidecar (additional) and init container images for Kubernetes services via new `container_images` and `init_container_images` JSON inputs. Main `image` is now optional when one of these is provided. Only applicable when `type=service`.
+
 ### Fixed
 
 - Restored `mask-account-id` default to `false`, matching the historical effective behavior where the previous default of `'yes'` was silently evaluated as `false` by `aws-actions/configure-aws-credentials@v4`

--- a/update-image/README.md
+++ b/update-image/README.md
@@ -1,19 +1,28 @@
 # Update Image Action
 
-Updates any kind of container service with a new image.
+Updates any kind of container service with a new image. For Kubernetes services
+(`type: service`), this action also supports updating sidecar (additional) and
+init container images in the same call.
 
 ## Inputs
 
 The following input variables can be configured:
 
-| Name  | Description                              | Required | Default Value |
-|-------|------------------------------------------|----------|---------------|
-| name  | Service name                             | Yes      |               |
-| image | Image name                               | Yes      |               |
-| type  | Options: `service`, `lambda`, `ecs`, `cronjob` | No       | `service`      |
-| wait  | Wait for deployment                      | No       | `false`        |
+| Name                    | Description                                                                                                  | Required | Default Value |
+|-------------------------|--------------------------------------------------------------------------------------------------------------|----------|---------------|
+| name                    | Service name                                                                                                 | Yes      |               |
+| image                   | Image name for the main container. Optional when only updating sidecar or init container images.             | No       |               |
+| type                    | Options: `service`, `lambda`, `ecs`, `cronjob`                                                               | No       | `service`     |
+| container_images        | JSON array of sidecar container name/image pairs. Format: `[{"name": "sidecar1", "image": "image1:tag"}]`. Only supported when `type=service`. | No       |               |
+| init_container_images   | JSON array of init container name/image pairs. Format: `[{"name": "init1", "image": "image1:tag"}]`. Only supported when `type=service`.       | No       |               |
+| wait                    | Wait for deployment                                                                                          | No       | `false`       |
+
+At least one of `image`, `container_images`, or `init_container_images` must be
+provided.
 
 ## Example Usage
+
+### Update the main container
 
 ```yaml
 name: Deploy Service
@@ -37,6 +46,37 @@ jobs:
         type: service
         name: my-service
         image: my-image:latest
+```
 
-    # Add more steps for your deployment process...
+### Update main, sidecar, and init container images together
+
+```yaml
+    - name: Update Image
+      uses: duplocloud/actions/update-image@v1
+      with:
+        type: service
+        name: my-service
+        image: myregistry/main:v1.2.3
+        container_images: |
+          [
+            {"name": "logger", "image": "myregistry/logger:v1.2.3"},
+            {"name": "proxy",  "image": "myregistry/proxy:v1.2.3"}
+          ]
+        init_container_images: |
+          [
+            {"name": "init-db", "image": "myregistry/init-db:v1.2.3"}
+          ]
+        wait: "true"
+```
+
+### Update only sidecar containers (leave main image unchanged)
+
+```yaml
+    - name: Update Sidecars
+      uses: duplocloud/actions/update-image@v1
+      with:
+        type: service
+        name: my-service
+        container_images: |
+          [{"name": "logger", "image": "myregistry/logger:v1.3.0"}]
 ```

--- a/update-image/action.yml
+++ b/update-image/action.yml
@@ -1,16 +1,31 @@
 name: Update Service
-description: Updates an image for a number of container types. 
+description: Updates an image for a number of container types.
 inputs:
   type:
     description: Service type
-    required: false 
+    required: false
     default: service
   name:
     description: Service name
     required: true
   image:
-    description: Image URI
-    required: true
+    description: Image URI for the main container. Optional when only updating sidecar or init container images.
+    required: false
+    default: ""
+  container_images:
+    description: |
+      JSON array of sidecar (additional) container name/image pairs.
+      Format: [{"name": "sidecar1", "image": "image1:tag"}]
+      Only supported when type=service.
+    required: false
+    default: ""
+  init_container_images:
+    description: |
+      JSON array of init container name/image pairs.
+      Format: [{"name": "init1", "image": "image1:tag"}]
+      Only supported when type=service.
+    required: false
+    default: ""
   wait:
     description: Wait for deployment
     required: false
@@ -36,9 +51,49 @@ runs:
       RESOURCE: ${{ inputs.type }}
       NAME: ${{ inputs.name }}
       IMAGE: ${{ inputs.image }}
+      CONTAINER_IMAGES: ${{ inputs.container_images }}
+      INIT_CONTAINER_IMAGES: ${{ inputs.init_container_images }}
+      WAIT: ${{ inputs.wait }}
     run: |
-      if [[ "${{ inputs.wait }}" == "true" ]]; then
-        duploctl $RESOURCE update_image $NAME $IMAGE --wait
-      else
-        duploctl $RESOURCE update_image $NAME $IMAGE
+      set -euo pipefail
+
+      if [ -z "$IMAGE" ] && [ -z "$CONTAINER_IMAGES" ] && [ -z "$INIT_CONTAINER_IMAGES" ]; then
+        echo "::error::Provide at least one of: image, container_images, or init_container_images"
+        exit 1
       fi
+
+      if { [ -n "$CONTAINER_IMAGES" ] || [ -n "$INIT_CONTAINER_IMAGES" ]; } && [ "$RESOURCE" != "service" ]; then
+        echo "::error::container_images and init_container_images are only supported when type=service"
+        exit 1
+      fi
+
+      if [ -n "$CONTAINER_IMAGES" ] || [ -n "$INIT_CONTAINER_IMAGES" ]; then
+        command -v jq >/dev/null || { echo "::error::jq is required to parse container_images / init_container_images"; exit 1; }
+      fi
+
+      ARGS=("duploctl" "$RESOURCE" "update_image" "$NAME")
+      if [ -n "$IMAGE" ]; then
+        ARGS+=("$IMAGE")
+      fi
+
+      if [ -n "$CONTAINER_IMAGES" ]; then
+        while IFS= read -r line; do
+          CNAME=$(echo "$line" | jq -r '.name')
+          CIMG=$(echo "$line" | jq -r '.image')
+          ARGS+=("--container-image" "$CNAME" "$CIMG")
+        done < <(echo "$CONTAINER_IMAGES" | jq -c '.[]')
+      fi
+
+      if [ -n "$INIT_CONTAINER_IMAGES" ]; then
+        while IFS= read -r line; do
+          CNAME=$(echo "$line" | jq -r '.name')
+          CIMG=$(echo "$line" | jq -r '.image')
+          ARGS+=("--init-container-image" "$CNAME" "$CIMG")
+        done < <(echo "$INIT_CONTAINER_IMAGES" | jq -c '.[]')
+      fi
+
+      if [ "$WAIT" = "true" ]; then
+        ARGS+=("--wait")
+      fi
+
+      "${ARGS[@]}"

--- a/update-image/action.yml
+++ b/update-image/action.yml
@@ -61,18 +61,35 @@ runs:
     run: |
       set -euo pipefail
 
-      if [ -z "$IMAGE" ] && [ -z "$CONTAINER_IMAGES" ] && [ -z "$INIT_CONTAINER_IMAGES" ]; then
-        echo "::error::Provide at least one of: image, container_images, or init_container_images"
-        exit 1
-      fi
-
-      if { [ -n "$CONTAINER_IMAGES" ] || [ -n "$INIT_CONTAINER_IMAGES" ]; } && [ "$RESOURCE" != "service" ]; then
-        echo "::error::container_images and init_container_images are only supported when type=service"
-        exit 1
-      fi
+      CONTAINER_COUNT=0
+      INIT_CONTAINER_COUNT=0
 
       if [ -n "$CONTAINER_IMAGES" ] || [ -n "$INIT_CONTAINER_IMAGES" ]; then
         command -v jq >/dev/null || { echo "::error::jq is required to parse container_images / init_container_images"; exit 1; }
+
+        if [ -n "$CONTAINER_IMAGES" ]; then
+          if ! CONTAINER_COUNT=$(echo "$CONTAINER_IMAGES" | jq -e 'if type == "array" then length else error("not an array") end' 2>/dev/null); then
+            echo "::error::container_images must be a valid JSON array"
+            exit 1
+          fi
+        fi
+
+        if [ -n "$INIT_CONTAINER_IMAGES" ]; then
+          if ! INIT_CONTAINER_COUNT=$(echo "$INIT_CONTAINER_IMAGES" | jq -e 'if type == "array" then length else error("not an array") end' 2>/dev/null); then
+            echo "::error::init_container_images must be a valid JSON array"
+            exit 1
+          fi
+        fi
+      fi
+
+      if [ -z "$IMAGE" ] && [ "$CONTAINER_COUNT" -eq 0 ] && [ "$INIT_CONTAINER_COUNT" -eq 0 ]; then
+        echo "::error::Provide at least one of: image, container_images (non-empty), or init_container_images (non-empty)"
+        exit 1
+      fi
+
+      if { [ "$CONTAINER_COUNT" -gt 0 ] || [ "$INIT_CONTAINER_COUNT" -gt 0 ]; } && [ "$RESOURCE" != "service" ]; then
+        echo "::error::container_images and init_container_images are only supported when type=service"
+        exit 1
       fi
 
       ARGS=("duploctl" "$RESOURCE" "update_image" "$NAME")
@@ -80,7 +97,7 @@ runs:
         ARGS+=("$IMAGE")
       fi
 
-      if [ -n "$CONTAINER_IMAGES" ]; then
+      if [ "$CONTAINER_COUNT" -gt 0 ]; then
         while IFS= read -r line; do
           CNAME=$(echo "$line" | jq -r '.name')
           CIMG=$(echo "$line" | jq -r '.image')
@@ -88,7 +105,7 @@ runs:
         done < <(echo "$CONTAINER_IMAGES" | jq -c '.[]')
       fi
 
-      if [ -n "$INIT_CONTAINER_IMAGES" ]; then
+      if [ "$INIT_CONTAINER_COUNT" -gt 0 ]; then
         while IFS= read -r line; do
           CNAME=$(echo "$line" | jq -r '.name')
           CIMG=$(echo "$line" | jq -r '.image')


### PR DESCRIPTION
## Summary

Extends the `update-image` action so Kubernetes services can update sidecar (additional) and init container images alongside (or instead of) the main container image.

This is the GitHub-Actions half of DUPLO-29546. The duploctl half shipped in [duploctl#244](https://github.com/duplocloud/duploctl/pull/244), which switched `service update_image` to the V3 `containerimage` endpoint that already accepts a list of `{ContainerName, ImageName}` pairs. This PR exposes those flags through the action.

## Changes

- New optional inputs on `update-image`:
  - `container_images` — JSON array of `{name, image}` for sidecars
  - `init_container_images` — JSON array of `{name, image}` for init containers
- `image` is now optional; at least one of the three must be provided
- Sidecar/init inputs are only valid when `type=service`; the action errors out with a clear message otherwise
- Run script rewritten to build args as a bash array (safer quoting); validates `jq` presence when JSON inputs are used
- README updated with three usage examples
- CHANGELOG entry under `[Unreleased] / Added`

## Out of scope

The `update-images` (bulk) action is unchanged. duploctl's `bulk_update_image` still only accepts main-container `-S name image` pairs; extending bulk would need a duploctl change first.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-29546

## Test plan

- [x] Local validation of action bash logic against a `duploctl` shim — 6/6 cases pass (main only, all-three combined, sidecar only, missing-input error, wrong-type error, lambda main-only regression). The underlying `duploctl service update_image` flags this action forwards to (`--container-image`, `--init-container-image`) have been validated against a live K8s portal in [duploctl#244](https://github.com/duplocloud/duploctl/pull/244) and have been in production since that merge.