### PR TITLE
DUPLO-42854: Fix rules action protection gate using wrong input name

### DIFF
--- a/rules/action.yml
+++ b/rules/action.yml
@@ -39,7 +39,7 @@ runs:
     env:
       GH_ROLE: ${{ fromJson(steps.get_user_groups.outputs.data).role }}
       GH_TEAMS: ${{ steps.actorTeams.outputs.teams }}
-      GHA_ENV: ${{ inputs.environment }}
+      GHA_ENV: ${{ inputs.current_environment }}
       ISMEMBER: ${{ steps.actorTeams.outputs.isTeamMember }}
     run: |
       cat <<EOF
@@ -56,7 +56,7 @@ runs:
     shell: bash
     if: >
       steps.actorTeams.outputs.isTeamMember == 'false' &&
-      inputs.environment == inputs.protected_environment
+      inputs.current_environment == inputs.protected_environment
     run: |
       echo "User is not a member of the deployment team, and therefore cannot deploy to production."
       exit 1


### PR DESCRIPTION
## Summary

Fixes a bug where the `rules` composite action's deployment gate has never actually blocked unauthorized deploys.

The action declares `current_environment` as an input but the body referenced the non-existent `inputs.environment` in two places:

- `GHA_ENV` env var in the Display step → always blank
- Protection condition `inputs.environment == inputs.protected_environment` → always false, so the `exit 1` step never triggers

Replaces both occurrences with `inputs.current_environment`.

**Ticket:** [DUPLO-42854](https://app.clickup.com/t/8655600/DUPLO-42854)