### PR TITLE
DUPLO-43218: pip self-upgrade failure on Windows runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
   - name: Pip Upgrade
     if: inputs.python-version != 'none'
     shell: bash
-    run: pip install --upgrade pip
+    run: python -m pip install --upgrade pip
 
   - name: Check duploctl
     id: check-duploctl

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -54,7 +54,7 @@ runs:
 
   - name: Pip Upgrade
     shell: bash
-    run: pip install --upgrade pip
+    run: python -m pip install --upgrade pip
 
   - name: Install duploctl
     id: install-duploctl


### PR DESCRIPTION
## Ticket: https://app.clickup.com/t/8655600/DUPLO-43218

## Problem

Workflows using this action on **Windows runners** fail at the **Pip Upgrade** step with:

```
ERROR: To modify pip, please run the following command:
C:\hostedtoolcache\windows\Python\3.10.11\x64\python.exe -m pip install --upgrade pip
Error: Process completed with exit code 1.
```

## Root cause

The `pip install --upgrade pip` line is unchanged since 2024, so this is not a regression in the action. What changed is **external**: the GitHub-hosted Windows runner image bumped its bundled pip to **26.x**. Recent pip refuses to self-upgrade when invoked through the `pip.exe` launcher (the running `.exe` is locked) and now exits with code **1** instead of warning. Linux/macOS are unaffected, so only Windows jobs break.

## Fix

Use `python -m pip install --upgrade pip`. The `-m` form runs pip as a module, avoiding the locked `pip.exe`, and works on Linux, macOS, and Windows alike. This is the exact command pip's own error message recommends.

Changed in both:
- `action.yml`
- `setup/action.yml`