### PR TITLE
adding support for --wait-timeout to update_image(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 
 - Restored `mask-account-id` default to `false`, matching the historical effective behavior where the previous default of `'yes'` was silently evaluated as `false` by `aws-actions/configure-aws-credentials@v4`
 
+### Added
+
+- Added support for --wait-timeout for bulk and standard image updates
+
 ## [0.0.14] - 2026-03-19
 
 ### Added

--- a/update-image/action.yml
+++ b/update-image/action.yml
@@ -15,6 +15,9 @@ inputs:
     description: Wait for deployment
     required: false
     default: "false"
+  wait_timeout:
+    description: Timeout in seconds for the wait operation
+    required: false
 
 runs:
   using: composite
@@ -38,7 +41,11 @@ runs:
       IMAGE: ${{ inputs.image }}
     run: |
       if [[ "${{ inputs.wait }}" == "true" ]]; then
-        duploctl $RESOURCE update_image $NAME $IMAGE --wait
+        WAIT_ARGS="--wait"
+        if [[ -n "${{ inputs.wait_timeout }}" ]]; then
+          WAIT_ARGS="$WAIT_ARGS --wait-timeout ${{ inputs.wait_timeout }}"
+        fi
+        duploctl $RESOURCE update_image $NAME $IMAGE $WAIT_ARGS
       else
         duploctl $RESOURCE update_image $NAME $IMAGE
       fi

--- a/update-image/action.yml
+++ b/update-image/action.yml
@@ -39,13 +39,16 @@ runs:
       RESOURCE: ${{ inputs.type }}
       NAME: ${{ inputs.name }}
       IMAGE: ${{ inputs.image }}
+      WAIT: ${{ inputs.wait }}
+      WAIT_TIMEOUT: ${{ inputs.wait_timeout }}
     run: |
-      if [[ "${{ inputs.wait }}" == "true" ]]; then
-        WAIT_ARGS="--wait"
-        if [[ -n "${{ inputs.wait_timeout }}" ]]; then
-          WAIT_ARGS="$WAIT_ARGS --wait-timeout ${{ inputs.wait_timeout }}"
+      DUPLOCTL_ARGS=("duploctl" "$RESOURCE" "update_image" "$NAME" "$IMAGE")
+
+      if [ "$WAIT" = "true" ]; then
+        DUPLOCTL_ARGS+=("--wait")
+        if [ -n "$WAIT_TIMEOUT" ]; then
+          DUPLOCTL_ARGS+=("--wait-timeout" "$WAIT_TIMEOUT")
         fi
-        duploctl $RESOURCE update_image $NAME $IMAGE $WAIT_ARGS
-      else
-        duploctl $RESOURCE update_image $NAME $IMAGE
       fi
+
+      "${DUPLOCTL_ARGS[@]}"

--- a/update-images/action.yml
+++ b/update-images/action.yml
@@ -14,6 +14,9 @@ inputs:
     description: Wait for all deployments to complete
     required: false
     default: "false"
+  wait_timeout:
+    description: Timeout in seconds for the wait operation
+    required: false
   loglevel:
     description: Log level for duploctl output
     required: false
@@ -29,6 +32,7 @@ runs:
     env:
       SERVICES: ${{ inputs.services }}
       WAIT: ${{ inputs.wait }}
+      WAIT_TIMEOUT: ${{ inputs.wait_timeout }}
       LOGLEVEL: ${{ inputs.loglevel }}
     run: |
       set -euo pipefail
@@ -43,6 +47,9 @@ runs:
       # Add wait flag if requested
       if [ "$WAIT" = "true" ]; then
         DUPLOCTL_ARGS+=("--wait")
+        if [ -n "$WAIT_TIMEOUT" ]; then
+          DUPLOCTL_ARGS+=("--wait-timeout" "$WAIT_TIMEOUT")
+        fi
       fi
 
       # Add service-image pairs


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Add --wait-timeout support to update-image and update-images actions
<code>✨ Enhancement</code> <code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Add optional wait_timeout input to both image update composite actions.
• When wait=true, pass --wait-timeout through to duploctl.
• Document the new flag in the changelog.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  W["GitHub workflow"] --> A1["update-image action"] --> C(["duploctl"]) --> D["Duplo deployment"]
  W --> A2["update-images action"] --> C
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Validate wait_timeout input (numeric, &gt;0) before invoking duploctl</b></summary>

- ➕ Prevents confusing duploctl errors from invalid values
- ➕ Fails fast with a clear message at the action layer
- ➖ Adds a bit more bash logic and test/maintenance surface
- ➖ May diverge from duploctl&#x27;s own validation rules

</details>

<details>
<summary><b>2. Factor wait-arg construction into a shared helper step/script</b></summary>

- ➕ Reduces duplication between update-image and update-images
- ➕ Makes future wait-related options easier to add consistently
- ➖ Likely overkill for a small amount of duplication
- ➖ Adds another file/indirection for a simple feature

</details>

**Recommendation:** The current approach (adding an optional input and conditionally appending args) is appropriate for composite actions and keeps behavior backwards-compatible. If this action set is expected to grow more flags, consider a shared helper later; otherwise, keep as-is and optionally add minimal numeric validation for wait_timeout.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (2)</summary>

<blockquote>
<details>
<summary><strong>action.yml</strong> <code>Add wait_timeout input and forward --wait-timeout for update_image</code> <code>+8/-1</code></summary>

<br/>

>Add wait_timeout input and forward --wait-timeout for update_image
>
><pre>
>• Introduces an optional wait_timeout input. When wait=true, builds WAIT_ARGS to include --wait and conditionally appends --wait-timeout &lt;seconds&gt; before invoking duploctl.
></pre>
>
><a href='https://github.com/duplocloud/actions/pull/121/files#diff-5784903c938ebea33e28eee6aae21d06173c7431174a413e1ae821361d96ce09'>update-image/action.yml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>action.yml</strong> <code>Add wait_timeout input and append --wait-timeout for bulk updates</code> <code>+7/-0</code></summary>

<br/>

>Add wait_timeout input and append --wait-timeout for bulk updates
>
><pre>
>• Adds a wait_timeout input, exports it to the run environment, and conditionally appends --wait-timeout to DUPLOCTL_ARGS when WAIT is enabled.
></pre>
>
><a href='https://github.com/duplocloud/actions/pull/121/files#diff-c304b0df386300a9dc70a0c0b25219c52239634fe1987355349712964e588e63'>update-images/action.yml</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Document new --wait-timeout support for image updates</code> <code>+4/-0</code></summary>

<br/>

>Document new --wait-timeout support for image updates
>
><pre>
>• Adds a changelog entry noting support for the --wait-timeout flag for both bulk and standard image update actions.
></pre>
>
><a href='https://github.com/duplocloud/actions/pull/121/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed'>CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>