### PR TITLE
DUPLO-43548: add update-image-hdv2 action (HelpDesk V2 appservice + lambda)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- New `update-image-hdv2` action — the AI HelpDesk V2 (HDV2) counterpart to `update-image`. Updates a container image for an HDV2 workload within a workspace via duploctl: `type=service` (alias `eks`) targets `appservice` and `type=lambda` targets `hd_lambda`. Takes `name`, `image`, and one of `workspace`/`workspace_id`. ECS is not yet supported (no HDV2 backend endpoint; tracked in DUPLO-43548).
 - `update-image` action now supports updating sidecar (additional) and init container images for Kubernetes services via new `container_images` and `init_container_images` JSON inputs. Main `image` is now optional when one of these is provided. Only applicable when `type=service`.
 
 ## [0.1.0] - 2026-05-13

--- a/update-image-hdv2/README.md
+++ b/update-image-hdv2/README.md
@@ -1,0 +1,64 @@
+# Update Image (HelpDesk V2) Action
+
+Updates a container image for an AI HelpDesk V2 (HDV2) workload within a
+workspace. Supports EKS AppServices (`type: service`) and AWS Lambdas
+(`type: lambda`).
+
+> **Note:** ECS is not yet supported — the HelpDesk V2 backend has no ECS
+> update-image endpoint (tracked in DUPLO-43548). For Core Platform (non-HDV2)
+> services, ECS, and cronjobs, use the [`update-image`](../update-image) action.
+
+## Inputs
+
+The following input variables can be configured:
+
+| Name         | Description                                                                 | Required | Default Value |
+|--------------|-----------------------------------------------------------------------------|----------|---------------|
+| name         | Workload name as shown in the HelpDesk workspace                            | Yes      |               |
+| image        | New container image URI (e.g. an ECR image reference)                       | Yes      |               |
+| type         | Workload type. Options: `service` (alias `eks`), `lambda`                   | No       | `service`     |
+| workspace    | AI HelpDesk workspace name the workload belongs to                          | No       | `""`          |
+| workspace_id | AI HelpDesk workspace id. Skips the workspace name lookup when provided.    | No       | `""`          |
+
+One of `workspace` or `workspace_id` is required.
+
+## Example Usage
+
+### Update an EKS AppService image
+
+```yaml
+name: Deploy Service (HDV2)
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Duplo Setup
+      uses: duplocloud/actions@main
+
+    - name: Update Image
+      uses: duplocloud/actions/update-image-hdv2@v1
+      with:
+        type: service
+        name: my-appservice
+        image: my-image:latest
+        workspace: my-workspace
+```
+
+### Update an AWS Lambda image
+
+```yaml
+    - name: Update Lambda Image
+      uses: duplocloud/actions/update-image-hdv2@v1
+      with:
+        type: lambda
+        name: my-function
+        image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-fn:v1.2.3
+        workspace: my-workspace
+```

--- a/update-image-hdv2/action.yml
+++ b/update-image-hdv2/action.yml
@@ -40,7 +40,9 @@ runs:
     run: |
       set -euo pipefail
 
-      if [ -z "$DUPLO_HOST" ] || [ -z "$DUPLO_TOKEN" ] || [ -z "$DUPLO_TENANT" ]; then
+      # Use :- defaults so `set -u` doesn't abort with a cryptic "unbound
+      # variable" when the Duplo Setup step was skipped and these are unset.
+      if [ -z "${DUPLO_HOST:-}" ] || [ -z "${DUPLO_TOKEN:-}" ] || [ -z "${DUPLO_TENANT:-}" ]; then
         echo "::error::DUPLO_HOST, DUPLO_TOKEN, and DUPLO_TENANT must be set. Run the Duplo Setup action first."
         exit 1
       fi

--- a/update-image-hdv2/action.yml
+++ b/update-image-hdv2/action.yml
@@ -1,0 +1,81 @@
+name: Update Image (HelpDesk V2)
+description: >
+  Updates a container image for a HelpDesk V2 (HDV2) workload. Supports
+  EKS AppServices and AWS Lambdas within an AI HelpDesk workspace.
+inputs:
+  type:
+    description: Workload type. One of "service" (alias "eks") or "lambda".
+    required: false
+    default: service
+  name:
+    description: Workload name as shown in the HelpDesk workspace.
+    required: true
+  image:
+    description: New container image URI (e.g. an ECR image reference).
+    required: true
+  workspace:
+    description: AI HelpDesk workspace name the workload belongs to.
+    required: false
+    default: ""
+  workspace_id:
+    description: >
+      AI HelpDesk workspace id. Skips the workspace name lookup when
+      provided. One of workspace or workspace_id is required.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+
+  - name: Update Image
+    id: duploctl
+    shell: bash
+    env:
+      TYPE: ${{ inputs.type }}
+      NAME: ${{ inputs.name }}
+      IMAGE: ${{ inputs.image }}
+      WORKSPACE: ${{ inputs.workspace }}
+      WORKSPACE_ID: ${{ inputs.workspace_id }}
+    run: |
+      set -euo pipefail
+
+      if [ -z "$DUPLO_HOST" ] || [ -z "$DUPLO_TOKEN" ] || [ -z "$DUPLO_TENANT" ]; then
+        echo "::error::DUPLO_HOST, DUPLO_TOKEN, and DUPLO_TENANT must be set. Run the Duplo Setup action first."
+        exit 1
+      fi
+      command -v duploctl >/dev/null || { echo "::error::duploctl not found. Run the Duplo Setup action first."; exit 1; }
+
+      if [ -z "$IMAGE" ]; then
+        echo "::error::image is required"
+        exit 1
+      fi
+      if [ -z "$WORKSPACE" ] && [ -z "$WORKSPACE_ID" ]; then
+        echo "::error::one of workspace or workspace_id is required"
+        exit 1
+      fi
+
+      # Map the workload type to the HDV2 duploctl resource. ECS has no
+      # HelpDesk V2 update-image endpoint yet (tracked in DUPLO-43548), so it
+      # is rejected with a clear message rather than silently ignored.
+      case "$TYPE" in
+        service|eks) RESOURCE="appservice" ;;
+        lambda)      RESOURCE="hd_lambda" ;;
+        ecs)
+          echo "::error::type=ecs is not yet supported by HelpDesk V2 (no backend update-image endpoint). Tracked in DUPLO-43548."
+          exit 1
+          ;;
+        *)
+          echo "::error::Invalid type: $TYPE. Valid types: service (eks), lambda"
+          exit 1
+          ;;
+      esac
+
+      ARGS=("duploctl" "$RESOURCE" "update_image" "$NAME" "$IMAGE")
+      if [ -n "$WORKSPACE" ]; then
+        ARGS+=("--workspace" "$WORKSPACE")
+      else
+        ARGS+=("--workspace-id" "$WORKSPACE_ID")
+      fi
+
+      "${ARGS[@]}"


### PR DESCRIPTION
## Describe Changes

Adds a new `update-image-hdv2` composite action — the AI HelpDesk V2 (HDV2) counterpart to [`update-image`](../update-image). It updates a container image for an HDV2 workload within a workspace via `duploctl`:

- `type: service` (alias `eks`) → `duploctl appservice update_image`
- `type: lambda` → `duploctl hd_lambda update_image`

Inputs: `name`, `image` (required), `type` (default `service`), and one of `workspace` / `workspace_id`. Validates required env/inputs and the presence of `duploctl` up front, and rejects `type: ecs` with a clear message.

**ECS is intentionally excluded** — the HelpDesk V2 backend has no ECS update-image endpoint yet (tracked in DUPLO-43548). Core Platform / ECS / cronjob image updates continue to use the existing `update-image` action.

Depends on the duploctl `appservice` / `hd_lambda` resources added in duplocloud/duploctl#271.

## Link to Issues

https://app.clickup.com/t/8655600/DUPLO-43548
