### PR TITLE
fix: bump default duploctl version to 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - `update-image` action now supports updating sidecar (additional) and init container images for Kubernetes services via new `container_images` and `init_container_images` JSON inputs. Main `image` is now optional when one of these is provided. Only applicable when `type=service`.
 
+### Changed
+
+- Bumped the default duploctl version from 0.4.3 to 0.4.5, which includes the fix for the `'ReplicasActive'` KeyError during service wait polling
+
 ## [0.1.0] - 2026-05-13
 
 ### Fixed

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   version: 
     required: false
     description: The version of the duploctl to install.
-    default: '0.4.3'
+    default: '0.4.5'
   admin:
     required: false
     description: Admin user name.


### PR DESCRIPTION
## Problem

Workflows that don't pin `version` install duploctl **0.4.3** by default, which intermittently crashes mid-rollout during service wait polling:

```
An unexpected error occurred: 'ReplicasActive'
Error: Process completed with exit code 1.
```

The deployment itself succeeds — only the CI wait-check fails, breaking customer deploy workflows (e.g. `update-image` with `wait: true`).

## Root cause

duploctl 0.4.3 does a direct `svc['ReplicasActive']` dictionary access while polling service status. During a rolling deploy the Duplo API can return a status snapshot where that key is temporarily absent, raising an unhandled `KeyError`.

## Fix

Bump the root action's default duploctl version from `0.4.3` to `0.4.5`, which includes the fix (safe `.get()` access with graceful retry). The `setup/` sub-action already defaults to `latest` and is unaffected.